### PR TITLE
chore: fix typo in readme.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -41,7 +41,7 @@ First, you will need accounts at GraphCMS, Sendgrid and Now.
 git clone git@github.com:github.com/GraphCMS/nextjs-graphcms-podcast-starter.git
 cd nextjs-graphcms-podcast-starter
 yarn # npm install
-cp .env.buld.sample .env.build
+cp .env.build.sample .env.build
 cp .env.sample .env
 ```
 


### PR DESCRIPTION
```
cp .env.buld.sample .env.build
```
Missing "i" in build.
```
cp .env.build.sample .env.build
```
https://github.com/GraphCMS/nextjs-graphcms-podcast-starter#1-download-and-install-dependencies